### PR TITLE
Fix atomic decrement (operand order of emitted code was flipped).

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1492,12 +1492,12 @@ void JSWriter::generateInstruction(const Instruction *I, raw_string_ostream& Cod
     // Most bitcasts are no-ops for us. However, the exception is int to float and float to int
     switch (rmwi->getOperation()) {
       case AtomicRMWInst::Xchg: Code << getStore(I, P, I->getType(), VS, 0); break;
-      case AtomicRMWInst::Add:  Code << getStore(I, P, I->getType(), "((" + VS + '+' + iName + ")|0)", 0); break;
-      case AtomicRMWInst::Sub:  Code << getStore(I, P, I->getType(), "((" + VS + '-' + iName + ")|0)", 0); break;
-      case AtomicRMWInst::And:  Code << getStore(I, P, I->getType(), "(" + VS + '&' + iName + ")", 0); break;
-      case AtomicRMWInst::Nand: Code << getStore(I, P, I->getType(), "(~(" + VS + '&' + iName + "))", 0); break;
-      case AtomicRMWInst::Or:   Code << getStore(I, P, I->getType(), "(" + VS + '|' + iName + ")", 0); break;
-      case AtomicRMWInst::Xor:  Code << getStore(I, P, I->getType(), "(" + VS + '^' + iName + ")", 0); break;
+      case AtomicRMWInst::Add:  Code << getStore(I, P, I->getType(), "((" + iName + '+' + VS + ")|0)", 0); break;
+      case AtomicRMWInst::Sub:  Code << getStore(I, P, I->getType(), "((" + iName + '-' + VS + ")|0)", 0); break;
+      case AtomicRMWInst::And:  Code << getStore(I, P, I->getType(), "(" + iName + '&' + VS + ")", 0); break;
+      case AtomicRMWInst::Nand: Code << getStore(I, P, I->getType(), "(~(" + iName + '&' + VS + "))", 0); break;
+      case AtomicRMWInst::Or:   Code << getStore(I, P, I->getType(), "(" + iName + '|' + VS + ")", 0); break;
+      case AtomicRMWInst::Xor:  Code << getStore(I, P, I->getType(), "(" + iName + '^' + VS + ")", 0); break;
       case AtomicRMWInst::Max:
       case AtomicRMWInst::Min:
       case AtomicRMWInst::UMax:


### PR DESCRIPTION
This code resulted in wrong code being emitted for __sync_sub_and_fetch(val, 1), as it would emit "1-val" instead of "val-1", which would negate the result. I swapped the operand order to fix it. I did the same for all other atomic ops for consistency (everything but Sub should be commutative so it wouldn't matter).
