### PR TITLE
Expand single-use pure instructions inline.

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -364,7 +364,7 @@ DEF_CALL_HANDLER(llvm_memmove_p0i8_p0i8_i32, {
 })
 
 DEF_CALL_HANDLER(llvm_expect_i32, {
-  return getAssign(CI) + getValueAsStr(CI->getOperand(0));
+  return getAssignIfNeeded(CI) + getValueAsStr(CI->getOperand(0));
 })
 
 DEF_CALL_HANDLER(llvm_dbg_declare, {

--- a/test/CodeGen/JS/basics.ll
+++ b/test/CodeGen/JS/basics.ll
@@ -1,13 +1,7 @@
 ; RUN: llc < %s -march=js -o - | FileCheck %s
 
 ; CHECK: function _simple_integer_math(
-; CHECK:   [[VAL_A:\$[a-z]+]] = [[VAL_A]]|0;
-; CHECK:   [[VAL_B:\$[a-z]+]] = [[VAL_B]]|0;
-; CHECK:   [[VAL_C:\$[a-z]+]] = (([[VAL_A]]) + ([[VAL_B]]))|0;
-; CHECK:   [[VAL_D:\$[a-z]+]] = ([[VAL_C]]*20)|0;
-; CHECK:   [[VAL_E:\$[a-z]+]] = (([[VAL_D]]|0) / ([[VAL_A]]|0))&-1;
-; CHECK:   [[VAL_F:\$[a-z]+]] = (([[VAL_E]]) - 3)|0;
-; CHECK:   return ([[VAL_F]]|0);
+; CHECK:   return (((((((((((($a) + ($b))|0)*20)|0)|0) / ($a|0))&-1)) - 3)|0)|0);
 define i32 @simple_integer_math(i32 %a, i32 %b) nounwind {
   %c = add i32 %a, %b
   %d = mul i32 %c, 20
@@ -18,9 +12,7 @@ define i32 @simple_integer_math(i32 %a, i32 %b) nounwind {
 
 ; CHECK: function _fneg(
 ; CHECK:   [[VAL_D:\$[a-z]+]] = +[[VAL_D]]
-; CHECK:   [[VAL_F:\$[a-z]+]] = +0
-; CHECK:   [[VAL_F]] = -[[VAL_D]]
-; CHECK:   return (+[[VAL_F]]);
+; CHECK:   return (+(-[[VAL_D]]));
 define double @fneg(double %d) nounwind {
   %f = fsub double -0.0, %d
   ret double %f

--- a/test/CodeGen/JS/expect-intrinsics.ll
+++ b/test/CodeGen/JS/expect-intrinsics.ll
@@ -2,8 +2,7 @@
 
 ; Handle the llvm.expect intrinsic.
 
-; CHECK: $expval = $x;
-; CHECK: $tobool = ($expval|0)!=(0);
+; CHECK: if (((($x)|0)!=(0)))
 define void @foo(i32 %x) {
 entry:
   %expval = call i32 @llvm.expect.i32(i32 %x, i32 0)

--- a/test/CodeGen/JS/getelementptr.ll
+++ b/test/CodeGen/JS/getelementptr.ll
@@ -5,7 +5,7 @@
 target datalayout = "e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:128-n32-S128"
 
 ; CHECK: function _getelementptr([[VAL_P:\$[a-z_]+]]) {
-; CHECK:  [[GEP:\$[a-z_]+]] = (([[GEPINT:\$[a-z_]+]]) + 588)|0;
+; CHECK: return (((((([[VAL_P]])) + 588)|0))|0);
 define i32* @getelementptr([10 x [12 x i32] ]* %p) {
   %t = getelementptr [10 x [12 x i32]]* %p, i32 1, i32 2, i32 3
   ret i32* %t

--- a/test/CodeGen/JS/globals.ll
+++ b/test/CodeGen/JS/globals.ll
@@ -8,9 +8,7 @@
 ; CHECK:  [[VAR_u:\$[a-z]+]] = HEAP8[24]|0;
 ; CHECK:  [[VAR_a:\$[a-z]+]] = (~~(([[VAR_s:\$[a-z]+]]))>>>0);
 ; CHECK:  [[VAR_b:\$[a-z]+]] = [[VAR_u:\$[a-z]+]] << 24 >> 24;
-; CHECK:  [[VAR_c:\$[a-z]+]] = (([[VAR_t:\$[a-z]+]]) + ([[VAR_a:\$[a-z]+]]))|0;
-; CHECK:  [[VAR_d:\$[a-z]+]] = (([[VAR_c:\$[a-z]+]]) + ([[VAR_b:\$[a-z]+]]))|0;
-; CHECK:  return ([[VAR_d:\$[a-z]+]]|0);
+; CHECK:  return ((((((([[VAR_t]]) + ([[VAR_a]]))|0)) + ([[VAR_b]]))|0)|0);
 define i32 @loads() {
   %t = load i32* @A
   %s = load double* @B


### PR DESCRIPTION
This is mostly redundant with the JS optimizers, but it speeds up sqlite
compilation time by 10%.
