### PR TITLE
Fixed emscripten build

### DIFF
--- a/include/llvm/Support/Host.h
+++ b/include/llvm/Support/Host.h
@@ -16,7 +16,7 @@
 
 #include "llvm/ADT/StringMap.h"
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__asmjs__)
 #include <endian.h>
 #else
 #ifndef LLVM_ON_WIN32

--- a/lib/Support/Unix/Process.inc
+++ b/lib/Support/Unix/Process.inc
@@ -36,7 +36,11 @@
 #  include <termios.h>
 #endif
 
+#if !defined(__EMSCRIPTEN__)
 #include <sys/unistd.h>
+#else
+#include <unistd.h>
+#endif
 
 //===----------------------------------------------------------------------===//
 //=== WARNING: Implementation here must contain only generic UNIX code that

--- a/lib/Support/Unix/Signals.inc
+++ b/lib/Support/Unix/Signals.inc
@@ -18,6 +18,12 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+
+#if defined(__EMSCRIPTEN__)
+  #undef HAVE_CXXABI_H
+  #undef HAVE_DLFCN_H
+#endif
+
 #if HAVE_EXECINFO_H
 # include <execinfo.h>         // For backtrace().
 #endif
@@ -274,7 +280,7 @@ void llvm::sys::AddSignalHandler(void (*FnPtr)(void *), void *Cookie) {
 // On glibc systems we have the 'backtrace' function, which works nicely, but
 // doesn't demangle symbols.
 void llvm::sys::PrintStackTrace(FILE *FD) {
-#if defined(HAVE_BACKTRACE) && defined(ENABLE_BACKTRACES)
+#if defined(HAVE_BACKTRACE) && defined(ENABLE_BACKTRACES) && !defined(__EMSCRIPTEN__)
   static void* StackTrace[256];
   // Use backtrace() to output a backtrace on Linux systems with glibc.
   int depth = backtrace(StackTrace,

--- a/lib/Transforms/NaCl/ResolvePNaClIntrinsics.cpp
+++ b/lib/Transforms/NaCl/ResolvePNaClIntrinsics.cpp
@@ -187,6 +187,7 @@ struct IsLockFreeToConstant {
     // Continue.
 #   elif defined(__mips__) || defined(_M_IX86) // XXX Emscripten TODO: Move this fix to PNaCl upstream.
     MaxLockFreeByteSize = 4;
+#   elif defined(__EMSCRIPTEN__) || defined(__asmjs__)
 #   else
 #     error "Unknown architecture"
 #   endif


### PR DESCRIPTION
Hello I just fixed a few header-files blocking the build with emcc.
However, there is still an error that requires commenting out the `_LARGEFILE_64` defines in `emscripten/system/include/libc/stdio.h` I have not yet found a neat fix for that.
And one still needs `llvm-tblgen`, `clang-tblgen` and `llvm-config` form a _native build_   
