### PR TITLE
Support added for exceptions with ASYNCIFY

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -158,16 +158,6 @@ DEF_CALL_HANDLER(emscripten_landingpad, {
 DEF_CALL_HANDLER(emscripten_resume, {
   return "___resumeException(" + getValueAsCastStr(CI->getOperand(0)) + ")";
 })
-DEF_CALL_HANDLER(emscripten_async_postinvoke1, {
-  assert(InvokeState == 1 || InvokeState == 2); // normally 2, but can be 1 if the call in between was optimized out
-  InvokeState = 0;
-  return "";
-})
-DEF_CALL_HANDLER(emscripten_async_postinvoke2, {
-  assert(InvokeState == 0);
-  InvokeState = 2; // reset the state as if we've just done an invoke (it returned asynchronously)
-  return "";
-})
 
 // setjmp support
 
@@ -209,6 +199,17 @@ DEF_CALL_HANDLER(emscripten_alloc_async_context, {
 DEF_CALL_HANDLER(emscripten_check_async, {
   return getAssign(CI) + "___async";
 })
+DEF_CALL_HANDLER(emscripten_async_postinvoke1, {
+  assert(InvokeState == 1 || InvokeState == 2); // normally 2, but can be 1 if the call in between was optimized out
+  InvokeState = 0;
+  return "";
+})
+DEF_CALL_HANDLER(emscripten_async_postinvoke2, {
+  assert(InvokeState == 0);
+  InvokeState = 2; // reset the state as if we've just done an invoke (it returned asynchronously)
+  return "";
+})
+
 // prevent unwinding the stack
 // preserve the return value of the return inst
 DEF_CALL_HANDLER(emscripten_do_not_unwind, {
@@ -586,8 +587,6 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(__default__);
   SETUP_CALL_HANDLER(emscripten_preinvoke);
   SETUP_CALL_HANDLER(emscripten_postinvoke);
-  SETUP_CALL_HANDLER(emscripten_async_postinvoke1);
-  SETUP_CALL_HANDLER(emscripten_async_postinvoke2);
   SETUP_CALL_HANDLER(emscripten_landingpad);
   SETUP_CALL_HANDLER(emscripten_resume);
   SETUP_CALL_HANDLER(emscripten_prep_setjmp);
@@ -597,6 +596,8 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_get_longjmp_result);
   SETUP_CALL_HANDLER(emscripten_alloc_async_context);
   SETUP_CALL_HANDLER(emscripten_check_async);
+  SETUP_CALL_HANDLER(emscripten_async_postinvoke1);
+  SETUP_CALL_HANDLER(emscripten_async_postinvoke2);
   SETUP_CALL_HANDLER(emscripten_do_not_unwind);
   SETUP_CALL_HANDLER(emscripten_do_not_unwind_async);
   SETUP_CALL_HANDLER(emscripten_get_async_return_value_addr);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -158,6 +158,15 @@ DEF_CALL_HANDLER(emscripten_landingpad, {
 DEF_CALL_HANDLER(emscripten_resume, {
   return "___resumeException(" + getValueAsCastStr(CI->getOperand(0)) + ")";
 })
+DEF_CALL_HANDLER(emscripten_async_reinvoke, {
+  assert(InvokeState == 0);
+  InvokeState = 2; // reset the state as if we've just done an invoke (it returned asynchronously)
+  return "__THREW__ = " + CI->getOperand(0);
+})
+DEF_CALL_HANDLER(emscripten_async_queryinvoke, {
+  assert(InvokeState == 0);
+  return getAssign(CI) + "__THREW__";
+})
 
 // setjmp support
 

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -146,7 +146,7 @@ DEF_CALL_HANDLER(emscripten_postinvoke, {
   return getAssign(CI) + "__THREW__; __THREW__ = 0";
 })
 DEF_CALL_HANDLER(emscripten_landingpad, {
-  std::string Ret = getAssign(CI) + "___cxa_find_matching_catch(";
+  std::string Ret = "STACKTOP = st; " + getAssign(CI) + "___cxa_find_matching_catch(";
   unsigned Num = getNumArgOperands(CI);
   for (unsigned i = 1; i < Num-1; i++) { // ignore personality and cleanup XXX - we probably should not be doing that!
     if (i > 1) Ret += ",";

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -196,6 +196,13 @@ DEF_CALL_HANDLER(emscripten_alloc_async_context, {
       getValueAsStr(CI->getOperand(0)) + "," +
       getValueAsStr(CI->getOperand(1)) + ",sp)|0";
 })
+DEF_CALL_HANDLER(emscripten_free_async_context, {
+  // insert st as the 2nd parameter if we have it, -1 otherwise
+  return getAssign(CI) + "_emscripten_free_async_context(" +
+      getValueAsStr(CI->getOperand(0)) + "," +
+      (FunctionHasLandingpad ? "st" : "-1") +
+      ")|0";
+})
 DEF_CALL_HANDLER(emscripten_check_async, {
   return getAssign(CI) + "___async";
 })
@@ -595,6 +602,7 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_check_longjmp);
   SETUP_CALL_HANDLER(emscripten_get_longjmp_result);
   SETUP_CALL_HANDLER(emscripten_alloc_async_context);
+  SETUP_CALL_HANDLER(emscripten_free_async_context);
   SETUP_CALL_HANDLER(emscripten_check_async);
   SETUP_CALL_HANDLER(emscripten_async_postinvoke1);
   SETUP_CALL_HANDLER(emscripten_async_postinvoke2);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -198,9 +198,11 @@ DEF_CALL_HANDLER(emscripten_alloc_async_context, {
 })
 DEF_CALL_HANDLER(emscripten_free_async_context, {
   // insert st as the 2nd parameter if we have it, -1 otherwise
+  bool invoking = dyn_cast<ConstantInt>(CI->getOperand(1))->equalsInt(1);
+  assert(!invoking || FunctionHasLandingpad);
   return getAssign(CI) + "_emscripten_free_async_context(" +
       getValueAsStr(CI->getOperand(0)) + "," +
-      (FunctionHasLandingpad ? "st" : "-1") +
+      (invoking ? "st" : "-1") +
       ")|0";
 })
 DEF_CALL_HANDLER(emscripten_check_async, {

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -55,7 +55,7 @@ using namespace llvm;
 #define assert(x) { if (!(x)) report_fatal_error(#x); }
 #endif
 
-raw_ostream &prettyWarning() {
+static raw_ostream &prettyWarning() {
   errs().changeColor(raw_ostream::YELLOW);
   errs() << "warning:";
   errs().resetColor();

--- a/lib/Transforms/NaCl/LowerEmAsyncify.cpp
+++ b/lib/Transforms/NaCl/LowerEmAsyncify.cpp
@@ -424,8 +424,6 @@ void LowerEmAsyncify::FindContextVariables(AsyncCallEntry & Entry) {
   } else {
     resume_point:
     <if G was an invoke>:
-      // only call emscripten_async_reinvoke if we just called G;
-      // emscripten_async_resume set up the correct context if we're resuming
       emscripten_async_postinvoke2();
     %0'= either $0 or the async return value                      // callback func only
     ...

--- a/lib/Transforms/NaCl/LowerEmExceptionsPass.cpp
+++ b/lib/Transforms/NaCl/LowerEmExceptionsPass.cpp
@@ -151,7 +151,9 @@ bool LowerEmExceptions::runOnModule(Module &M) {
                                                CallArgs, "", II);
           NewCall->takeName(II);
           NewCall->setCallingConv(II->getCallingConv());
-          NewCall->setAttributes(II->getAttributes());
+		  AttributeSet attrs = II->getAttributes();
+		  attrs = attrs.addAttribute(M.getContext(), AttributeSet::FunctionIndex, "emscripten_invoke");
+          NewCall->setAttributes(attrs);
           NewCall->setDebugLoc(II->getDebugLoc());
           II->replaceAllUsesWith(NewCall);
           ToErase.push_back(II);

--- a/lib/Transforms/NaCl/LowerEmExceptionsPass.cpp
+++ b/lib/Transforms/NaCl/LowerEmExceptionsPass.cpp
@@ -151,8 +151,10 @@ bool LowerEmExceptions::runOnModule(Module &M) {
                                                CallArgs, "", II);
           NewCall->takeName(II);
           NewCall->setCallingConv(II->getCallingConv());
-		  AttributeSet attrs = II->getAttributes();
-		  attrs = attrs.addAttribute(M.getContext(), AttributeSet::FunctionIndex, "emscripten_invoke");
+          AttributeSet attrs = II->getAttributes();
+          // We set the "emscripten_invoke" attribute on the call instruction, so that
+          // later passes can recognise that the call site has special semantics
+          attrs = attrs.addAttribute(M.getContext(), AttributeSet::FunctionIndex, "emscripten_invoke");
           NewCall->setAttributes(attrs);
           NewCall->setDebugLoc(II->getDebugLoc());
           II->replaceAllUsesWith(NewCall);


### PR DESCRIPTION
_See matching emscripten pull request [#2772](https://github.com/kripken/emscripten/pull/2772)._

We add support for exceptions with asynchronous functions. Changes:
1. The LowerEmExceptions pass turns "invoke" instructions into "call" instructions plus some gloop. Rather than trying to recognise the gloop, I've added a function attribute "emscripten_invoke" to the resulting call instruction so that LowerEmAsyncify can easily spot which call instructions are inside try blocks.
2. LowerEmAsyncify mangles the invoke sequence by splitting the block right after the call instruction. I've fixed this up by adding a call to "emscripten_async_postinvoke1" just before the split on the other side of the split "emscripten_async_postinvoke2". These functions do nothing, they just set and assert the `InvokeState` variable so that illegal reordering of the invoke sequence by optimisations will be detected.
3. Finally, we've added a third instruction to `emscripten_alloc_async_context` so that a flag is set in the context indicating where it's a checked asynchronous call (invoke) or unchecked.
