### PR TITLE
don't legalize f32 calls when emulated function pointers

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -507,7 +507,7 @@ namespace {
       //       we don't need this, as we'll add a use in
       //       DeclaresNeedingTypeDeclarations which will have the proper type,
       //       and nothing will contradict it/overload it.
-      if (WebAssembly && F->isDeclaration() && usesFloat32(F->getFunctionType())) {
+      if (WebAssembly && !EmulatedFunctionPointers && F->isDeclaration() && usesFloat32(F->getFunctionType())) {
         Table.push_back(makeFloat32Legalizer(F));
       } else {
         Table.push_back(Name);


### PR DESCRIPTION
The emulated table is ok either way, it doesn't need legal calls like real wasm calls do.

This may fix https://github.com/kripken/emscripten/issues/5436, but should be tested carefully before landing.