### PR TITLE
Callhanders can be called with NULL, to just detect dependencies - atomics too

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -843,17 +843,21 @@ DEF_CALL_HANDLER(emscripten_asm_const_async_on_main_thread, {
 
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_exchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_exchange(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_exchange(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(__atomic_exchange_8, {
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   if (EnablePthreads) {
     return getAssign(CI) + '(' + (OnlyWebAssembly ? "i64_atomics_exchange" : "_emscripten_atomic_exchange_u64") + '(' + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
   } else {
@@ -863,27 +867,33 @@ DEF_CALL_HANDLER(__atomic_exchange_8, {
 
 DEF_CALL_HANDLER(emscripten_atomic_cas_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_compareExchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ',' + getValueAsStr(CI->getOperand(2)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_cas_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_compareExchange(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ',' + getValueAsStr(CI->getOperand(2)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_cas_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_compareExchange(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ',' + getValueAsStr(CI->getOperand(2)) + ")|0)";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_load_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_load(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_load(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_load(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_f32, {
@@ -891,6 +901,7 @@ DEF_CALL_HANDLER(emscripten_atomic_load_f32, {
   // we must emulate manually.
   Declares.insert("_Atomics_load_f32_emulated");
   UsesMathFround = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + (PreciseF32 ? "Math_fround(" : "+") + "__Atomics_load_f32_emulated(" + getShiftedPtr(CI->getOperand(0), 4) + (PreciseF32 ? "))" : ")");
 //  return getAssign(CI) + "Atomics_load(HEAPF32, " + getShiftedPtr(CI->getOperand(0), 4) + ')';
 })
@@ -898,6 +909,7 @@ DEF_CALL_HANDLER(emscripten_atomic_load_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
   Declares.insert("emscripten_atomic_load_f64");
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "+_emscripten_atomic_load_f64(" + getShiftedPtr(CI->getOperand(0), 8) + ')';
 //  return getAssign(CI) + "Atomics_load(HEAPF64, " + getShiftedPtr(CI->getOperand(0), 8) + ')';
 })
@@ -906,25 +918,30 @@ DEF_CALL_HANDLER(__atomic_load_8, {
   if (EnablePthreads && OnlyWebAssembly) op = "i64_atomics_load";
   else if (OnlyWebAssembly) op = "load8";
   else op = "_emscripten_atomic_load_u64";
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + '(' + op + '(' + getValueAsStr(CI->getOperand(0)) + ")|0)";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_store_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_store(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_store(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_store(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_f32, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
   Declares.insert("emscripten_atomic_store_f32");
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "_emscripten_atomic_store_f32(" + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ')';
 //  return getAssign(CI) + "Atomics_store(HEAPF32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ')';
 })
@@ -932,6 +949,7 @@ DEF_CALL_HANDLER(emscripten_atomic_store_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
   Declares.insert("emscripten_atomic_store_f64");
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "+_emscripten_atomic_store_f64(" + getShiftedPtr(CI->getOperand(0), 8) + ',' + getValueAsStr(CI->getOperand(1)) + ')';
 //  return getAssign(CI) + "Atomics_store(HEAPF64, " + getShiftedPtr(CI->getOperand(0), 8) + ',' + getValueAsStr(CI->getOperand(1)) + ')';
 })
@@ -940,19 +958,23 @@ DEF_CALL_HANDLER(__atomic_store_8, {
   if (EnablePthreads && OnlyWebAssembly) op = "i64_atomics_store";
   else if (OnlyWebAssembly) op = "store8";
   else op = "_emscripten_atomic_store_u64";
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return std::string("(") + op + '(' + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_add_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_add(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_add(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_add(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(__atomic_fetch_add_8, {
@@ -960,19 +982,23 @@ DEF_CALL_HANDLER(__atomic_fetch_add_8, {
   if (EnablePthreads && OnlyWebAssembly) op = "i64_atomics_add";
   else if (OnlyWebAssembly) op = "i64_add";
   else op = "__emscripten_atomic_fetch_and_add_u64";
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + '(' + op + '(' + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_sub_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_sub(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_sub(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_sub(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(__atomic_fetch_sub_8, {
@@ -980,19 +1006,23 @@ DEF_CALL_HANDLER(__atomic_fetch_sub_8, {
   if (EnablePthreads && OnlyWebAssembly) op = "i64_atomics_sub";
   else if (OnlyWebAssembly) op = "i64_sub";
   else op = "__emscripten_atomic_fetch_and_sub_u64";
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + '(' + op + '(' + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_and_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_and(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_and_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_and(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_and_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_and(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(__atomic_fetch_and_8, {
@@ -1000,19 +1030,23 @@ DEF_CALL_HANDLER(__atomic_fetch_and_8, {
   if (EnablePthreads && OnlyWebAssembly) op = "i64_atomics_and";
   else if (OnlyWebAssembly) op = "i64_and";
   else op = "__emscripten_atomic_fetch_and_and_u64";
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + '(' + op + '(' + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_or_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_or(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_or_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_or(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_or_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_or(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(__atomic_fetch_or_8, {
@@ -1020,19 +1054,23 @@ DEF_CALL_HANDLER(__atomic_fetch_or_8, {
   if (EnablePthreads && OnlyWebAssembly) op = "i64_atomics_or";
   else if (OnlyWebAssembly) op = "i64_or";
   else op = "__emscripten_atomic_fetch_and_or_u64";
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + '(' + op + '(' + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_xor_u8, {
   UsesInt8Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_xor(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_xor_u16, {
   UsesInt16Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_xor(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(emscripten_atomic_xor_u32, {
   UsesInt32Array = true;
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + "(Atomics_xor(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 DEF_CALL_HANDLER(__atomic_fetch_xor_8, {
@@ -1040,6 +1078,7 @@ DEF_CALL_HANDLER(__atomic_fetch_xor_8, {
   if (EnablePthreads && OnlyWebAssembly) op = "i64_atomics_xor";
   else if (OnlyWebAssembly) op = "i64_xor";
   else op = "__emscripten_atomic_fetch_and_xor_u64";
+  if (!CI) return ""; // we are just called from a handler that was called from getFunctionIndex, only to ensure the handler was run at least once
   return getAssign(CI) + '(' + op + '(' + getValueAsStr(CI->getOperand(0)) + ',' + getValueAsStr(CI->getOperand(1)) + ")|0)";
 })
 


### PR DESCRIPTION
(unlikely as taking their address might seem)