### PR TITLE
Perform with.overflow expansion before struct reg expansion

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -4775,6 +4775,10 @@ bool JSTargetMachine::addPassesToEmitFile(PassManagerBase &PM, raw_pwrite_stream
     // function arguments and returns into something ExpandStructRegs can expand.
     PM.add(createSimplifyStructRegSignaturesPass());
 
+    // ExpandStructRegs must be run after ExpandArithWithOverflow to expand out
+    // the insertvalue instructions that ExpandArithWithOverflow introduces.
+    PM.add(createExpandArithWithOverflowPass());
+
     // TODO(mtrofin) Remove the following and only run it as a post-opt pass once
     //               the following bug is fixed.
     // https://code.google.com/p/nativeclient/issues/detail?id=3857
@@ -4784,10 +4788,6 @@ bool JSTargetMachine::addPassesToEmitFile(PassManagerBase &PM, raw_pwrite_stream
 
     if (EnableEmAsyncify)
       PM.add(createLowerEmAsyncifyPass());
-
-    // ExpandStructRegs must be run after ExpandArithWithOverflow to expand out
-    // the insertvalue instructions that ExpandArithWithOverflow introduces.
-    PM.add(createExpandArithWithOverflowPass());
 
     // We place ExpandByVal after optimization passes because some byval
     // arguments can be expanded away by the ArgPromotion pass.  Leaving

--- a/test/CodeGen/JS/with-overflow.ll
+++ b/test/CodeGen/JS/with-overflow.ll
@@ -1,0 +1,19 @@
+; RUN: llc < %s | FileCheck %s
+
+target datalayout = "e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:128-n32-S128"
+target triple = "asmjs-unknown-emscripten"
+
+declare { i32, i1 } @llvm.uadd.with.overflow.i32(i32, i32)
+
+; CHECK-LABEL: function _test($x)
+; CHECK-NEXT: $x = $x|0;
+; CHECK-NEXT: var $a$arith = 0, label = 0, sp = 0;
+; CHECK-NEXT: sp = STACKTOP;
+; CHECK-NEXT: $a$arith = (($x) + 1)|0;
+; CHECK-NEXT: return ($a$arith|0);
+define i32 @test(i32 %x) {
+  %a = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %x, i32 1)
+  %b = insertvalue { i32, i1 } %a, i1 false, 1
+  %c = extractvalue { i32, i1 } %b, 0
+  ret i32 %c
+}


### PR DESCRIPTION
Make sure ExpandArithWithOverflow runs before ExpandStructRegs. While the latter has a check to avoid processing struct returns of intrinsics, it only works when directly extracting from one. In https://github.com/rust-lang/rust/pull/58623 we ran into a case where an extractvalue of an insertvalue of a with.overflow intrinsic is performed, as shown in the test case.