### PR TITLE
When building relocatable code lookup function addresses dynamically via `fp$foo` functions

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1856,7 +1856,7 @@ std::string JSWriter::getConstant(const Constant* CV, AsmCast sign) {
   if (isa<ConstantPointerNull>(CV)) return "0";
 
   if (const Function *F = dyn_cast<Function>(CV)) {
-    if (!F->isDSOLocal() && Relocatable) {
+    if (Relocatable && !F->isDSOLocal() && !F->hasLocalLinkage()) {
       std::string Name = getOpName(F) + '$' + getFunctionSignature(F->getFunctionType());
       ExternalFuncs.insert(Name);
       // We access linked function addresses through calls, which we load at the


### PR DESCRIPTION
This means that the dynamic linker then assigned function pointers
and both main module and side module use `fp$foo` accessors to lookup
function addresses, just like they do for global addresses.

This allows the test_dylink_function_pointer_equality test in emscripten
to pass.

See https://github.com/emscripten-core/emscripten/issues/8268.