### PR TITLE
Cherry-pick upstream r357726

### DIFF
--- a/include/llvm/Support/ManagedStatic.h
+++ b/include/llvm/Support/ManagedStatic.h
@@ -46,7 +46,7 @@ template <typename T, size_t N> struct object_deleter<T[N]> {
 class ManagedStaticBase {
 protected:
 #ifndef LLVM_AVOID_CONSTEXPR_CTOR
-  mutable std::atomic<void *> Ptr;
+  mutable std::atomic<void *> Ptr{nullptr};
   mutable void (*DeleterFn)(void *) = nullptr;
   mutable const ManagedStaticBase *Next = nullptr;
 #else

--- a/lib/Support/CommandLine.cpp
+++ b/lib/Support/CommandLine.cpp
@@ -377,12 +377,10 @@ void OptionCategory::registerCategory() {
 // that this ManagedStatic uses constant initailization and not dynamic
 // initialization because it is referenced from cl::opt constructors, which run
 // dynamically in an arbitrary order.
-LLVM_REQUIRE_CONSTANT_INITIALIZATION ManagedStatic<SubCommand>
-    llvm::cl::TopLevelSubCommand;
+ManagedStatic<SubCommand> llvm::cl::TopLevelSubCommand;
 
 // A special subcommand that can be used to put an option into all subcommands.
-LLVM_REQUIRE_CONSTANT_INITIALIZATION ManagedStatic<SubCommand>
-    llvm::cl::AllSubCommands;
+ManagedStatic<SubCommand> llvm::cl::AllSubCommands;
 
 void SubCommand::registerSubCommand() {
   GlobalParser->registerSubCommand(this);


### PR DESCRIPTION
It's a fix to the previously cherry-picked patch.

commit 4312fee0a9fb5b2bfe4a52766a4abdd35f23c018
Author: Reid Kleckner <rnk@google.com>
Date:   Thu Apr 4 11:45:05 2019

    Appease STLs where std::atomic<void*> lacks a constexpr default ctor

    MSVC 2019 casts the pointer to a pointer-sized integer, which is a
    reinterpret_cast, which is invalid in a constexpr context, so I have to
    remove the LLVM_REQUIRES_CONSTANT_INITIALIZATION annotation for now.

    llvm-svn: 357716